### PR TITLE
Fix early page reveal before video loads

### DIFF
--- a/assests/js/loading.js
+++ b/assests/js/loading.js
@@ -269,7 +269,20 @@ class MusicController {
   const mainContent = document.getElementById("main-content");
 
   let isFullyLoaded = false;
-  let isVideoLoaded = true;
+  let isVideoLoaded = false;
+
+  if (loadingVideo) {
+    if (loadingVideo.readyState >= 3) {
+      isVideoLoaded = true;
+    } else {
+      loadingVideo.addEventListener("canplaythrough", () => {
+        isVideoLoaded = true;
+      });
+    }
+  } else {
+    // No loading video element; consider video loaded
+    isVideoLoaded = true;
+  }
 
   // Full page load
   window.addEventListener("load", () => {

--- a/assests/js/loadingcamera.js
+++ b/assests/js/loadingcamera.js
@@ -276,17 +276,31 @@ window.startMusic = function () {
   let heroLoaded = false;
   let expandingLoaded = false;
 
-  // Listen for when the hero video is ready
-  heroVideo.addEventListener("canplaythrough", () => {
+  if (heroVideo) {
+    if (heroVideo.readyState >= 3) {
+      heroLoaded = true;
+    } else {
+      heroVideo.addEventListener("canplaythrough", () => {
+        heroLoaded = true;
+        checkVideosLoaded();
+      });
+    }
+  } else {
     heroLoaded = true;
-    checkVideosLoaded();
-  });
+  }
 
-  // Listen for when the expanding video is ready
-  expandingVideo.addEventListener("canplaythrough", () => {
+  if (expandingVideo) {
+    if (expandingVideo.readyState >= 3) {
+      expandingLoaded = true;
+    } else {
+      expandingVideo.addEventListener("canplaythrough", () => {
+        expandingLoaded = true;
+        checkVideosLoaded();
+      });
+    }
+  } else {
     expandingLoaded = true;
-    checkVideosLoaded();
-  });
+  }
 
   // Check if both videos are loaded
   function checkVideosLoaded() {

--- a/assests/js/loadingindex.js
+++ b/assests/js/loadingindex.js
@@ -275,22 +275,33 @@ window.startMusic = function () {
   // Flags to track each video load status
   let heroLoaded = false;
 
-  // Listen for when the hero video is ready
-  heroVideo.addEventListener("canplaythrough", () => {
+  if (heroVideo) {
+    if (heroVideo.readyState >= 3) {
+      heroLoaded = true;
+    } else {
+      heroVideo.addEventListener("canplaythrough", () => {
+        heroLoaded = true;
+        checkVideosLoaded();
+      });
+    }
+  } else {
     heroLoaded = true;
-    checkVideosLoaded();
-  });
+  }
 
- // 2. Treat “missing” as already loaded
-let expandingLoaded = !expandingVideo;
+  // 2. Treat "missing" as already loaded
+  let expandingLoaded = !expandingVideo;
 
-// 3. Only add listeners if the element exists
-if (expandingVideo) {
-  expandingVideo.addEventListener("canplaythrough", () => {
-    expandingLoaded = true;
-    checkVideosLoaded();
-  });
-}
+  // 3. Only add listeners if the element exists
+  if (expandingVideo) {
+    if (expandingVideo.readyState >= 3) {
+      expandingLoaded = true;
+    } else {
+      expandingVideo.addEventListener("canplaythrough", () => {
+        expandingLoaded = true;
+        checkVideosLoaded();
+      });
+    }
+  }
   // Check if both videos are loaded
   function checkVideosLoaded() {
     if (heroLoaded && expandingLoaded) {


### PR DESCRIPTION
## Summary
- ensure `loading.js` waits for loading video to be ready
- handle cached video state for `loadingindex.js` and `loadingcamera.js`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844988913ec83318ef37acdb7d95c91