### PR TITLE
Fix video preload and scrolling

### DIFF
--- a/assests/css/style.css
+++ b/assests/css/style.css
@@ -2779,7 +2779,8 @@ Dirty Secret
   height: 55vh;
   background: #333;
   border-radius: 3vh;
-  transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+  /* Remove transition so cards follow scroll speed */
+  transition: none;
   overflow: hidden;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
 }
@@ -2815,7 +2816,8 @@ Dirty Secret
   font-family: "Syne";
   opacity: 0;
   transform: scale(0.5);
-  transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+  /* Remove transition to sync with scroll */
+  transition: none;
   white-space: nowrap;
   text-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
   z-index: 10;

--- a/ourwork.html
+++ b/ourwork.html
@@ -193,7 +193,7 @@
       <!-- Here is the snippet -->
       <div class="camera-capture-wrapper" style="margin-top: 15vh;">
           <div class="containercamera">
-            <video class="videocamera" autoplay muted playsinline></video>
+            <video class="videocamera" preload="auto" autoplay muted playsinline></video>
 
           </div>
         <div class="wave-text">
@@ -250,7 +250,7 @@
                 <div class="workvideos-pair">
                     <div class="workvideos-card workvideos-card-left">
                         <div class="workvideos-video-wrapper">
-                            <video class="workvideos-video" loop muted playsinline aria-label="Food & Beverages branding showcase">
+                            <video class="workvideos-video" preload="metadata" loop muted playsinline aria-label="Food & Beverages branding showcase">
                                 <source src="./assests/images/ourwork/fb (1).mp4" type="video/mp4">
                             </video>
                         </div>
@@ -258,7 +258,7 @@
                     <div class="workvideos-text">Food and Beverages</div>
                     <div class="workvideos-card workvideos-card-right">
                         <div class="workvideos-video-wrapper">
-                            <video class="workvideos-video" loop muted playsinline aria-label="Food & Beverages branding showcase">
+                            <video class="workvideos-video" preload="metadata" loop muted playsinline aria-label="Food & Beverages branding showcase">
                                 <source src="./assests/images/ourwork/fb (2).mp4" type="video/mp4">
                             </video>
                         </div>
@@ -273,7 +273,7 @@
                 <div class="workvideos-pair">
                     <div class="workvideos-card workvideos-card-left">
                         <div class="workvideos-video-wrapper">
-                            <video class="workvideos-video" loop muted playsinline aria-label="Fashion & Beauty branding showcase">
+                            <video class="workvideos-video" preload="metadata" loop muted playsinline aria-label="Fashion & Beauty branding showcase">
                                 <source src="./assests/images/ourwork/Fashion (1).mp4" type="video/mp4">
                             </video>
                         </div>
@@ -281,7 +281,7 @@
                     <div class="workvideos-text">Fashion and Beauty</div>
                     <div class="workvideos-card workvideos-card-right">
                         <div class="workvideos-video-wrapper">
-                            <video class="workvideos-video" loop muted playsinline aria-label="Fashion & Beauty branding showcase">
+                            <video class="workvideos-video" preload="metadata" loop muted playsinline aria-label="Fashion & Beauty branding showcase">
                                 <source src="./assests/images/ourwork/Fashion (2).mp4" type="video/mp4">
                             </video>
                         </div>
@@ -295,7 +295,7 @@
               <div class="workvideos-pair">
                   <div class="workvideos-card workvideos-card-left">
                       <div class="workvideos-video-wrapper">
-                          <video class="workvideos-video" loop muted playsinline  aria-label="Technology branding showcase">
+                          <video class="workvideos-video" preload="metadata" loop muted playsinline  aria-label="Technology branding showcase">
                               <source src="./assests/images/ourwork/tech (1).mp4" type="video/mp4">
                           </video>
                       </div>
@@ -303,7 +303,7 @@
                   <div class="workvideos-text">Technology</div>
                   <div class="workvideos-card workvideos-card-right">
                       <div class="workvideos-video-wrapper">
-                          <video class="workvideos-video" loop muted playsinline  aria-label="Technology branding showcase">
+                          <video class="workvideos-video" preload="metadata" loop muted playsinline  aria-label="Technology branding showcase">
                               <source src="./assests/images/ourwork/tech (2).mp4" type="video/mp4">
                           </video>
                       </div>
@@ -316,7 +316,7 @@
                 <div class="workvideos-pair">
                     <div class="workvideos-card workvideos-card-left">
                         <div class="workvideos-video-wrapper">
-                            <video class="workvideos-video" loop muted playsinline  aria-label="e-commerce branding showcase">
+                            <video class="workvideos-video" preload="metadata" loop muted playsinline  aria-label="e-commerce branding showcase">
                                 <source src="./assests/images/ourwork/pro (2).mp4" type="video/mp4">
                             </video>
                         </div>
@@ -324,7 +324,7 @@
                     <div class="workvideos-text">Product Promotions</div>
                     <div class="workvideos-card workvideos-card-right">
                         <div class="workvideos-video-wrapper">
-                            <video class="workvideos-video" loop muted playsinline  aria-label="e-commerce branding showcase">
+                            <video class="workvideos-video" preload="metadata" loop muted playsinline  aria-label="e-commerce branding showcase">
                                 <source src="./assests/images/ourwork/pro (1).mp4" type="video/mp4">
                             </video>
                         </div>


### PR DESCRIPTION
## Summary
- preload work videos so their thumbnails show before scrolling
- remove CSS transitions on work video cards and text for direct sync with scroll

## Testing
- `tidy -e ourwork.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dee9dc2e08331844a295218ba92cd